### PR TITLE
Plaid Refresh Page Fix

### DIFF
--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -1,7 +1,4 @@
 import { Component } from '@angular/core';
-import { AuthService } from './services/auth.service';
-import { filter } from 'rxjs/operators';
-import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-root',
@@ -9,8 +6,6 @@ import { Router } from '@angular/router';
   styleUrls: ['./app.component.scss']
 })
 export class AppComponent {
-  constructor(
-    private authService: AuthService,
-    private router: Router
-  ) {}
+
+  constructor() {}
 }

--- a/frontend/src/app/core/plaid/plaid.component.ts
+++ b/frontend/src/app/core/plaid/plaid.component.ts
@@ -17,13 +17,7 @@ export class PlaidComponent implements AfterViewInit {
   private plaidLinkHandler: PlaidLinkHandler;
 
   private config: PlaidConfig = {
-    apiVersion: "v2",
-    env: "sandbox",
-    token: null,
-    webhook: "https://clearviewmoney.com/dashboard",
-    product: ["auth"],
-    countryCodes: ['US'],
-    key: environment.plaid_public_key,
+    ...environment.plaid_default_config,
     onSuccess: this.onSuccess,
     onExit: this.onExit
   };
@@ -33,7 +27,7 @@ export class PlaidComponent implements AfterViewInit {
     private authService: AuthService,
     private router: Router,
     private plaidLinkService: NgxPlaidLinkService
-  ) { }
+  ) {}
 
   ngAfterViewInit() {
     this.plaidLinkService

--- a/frontend/src/app/core/plaid/plaid.component.ts
+++ b/frontend/src/app/core/plaid/plaid.component.ts
@@ -44,20 +44,6 @@ export class PlaidComponent implements AfterViewInit {
       });
   }
 
-  onPlaidSuccess(event) {
-    console.log('Success: ' + JSON.stringify(event));
-
-    this.authService.setHasPlaidToken(true);
-
-    // Save access token
-    this.apiService.post('/access-token', {
-      publicToken: event.token
-    })
-    .subscribe((response: any) => {
-      this.router.navigate(['/dashboard']);
-    });
-  }
-
   open() {
     this.plaidLinkHandler.open();
   }

--- a/frontend/src/app/services/auth.service.ts
+++ b/frontend/src/app/services/auth.service.ts
@@ -22,19 +22,12 @@ export class AuthService {
         private toastr: ToastrService,
         private httpClient: HttpClient,
         private backendService: BackendService
-    ) {
-        // On app initialization, call backend and try to fetch user/business details if id_token exists
-        // Making this synchronous b/c plaid-guard.service.ts depends on this information
-        if (this.getToken()) {
-            this.fetchUserInfo();
-        }
-    }
+    ) {}
 
     public async fetchUserInfo() {
         await this.backendService.getBusiness().toPromise().then(response => {
             if (response) {
                 if (response.plaidAccessToken) {
-                    console.log('lo tiene', response.plaidAccessToken);
                     this.hasPlaidToken = true;
                 }
             }

--- a/frontend/src/app/services/plaid-guard.service.ts
+++ b/frontend/src/app/services/plaid-guard.service.ts
@@ -20,6 +20,8 @@ export class PlaidGuardService {
           } else {
             this.router.navigate(['/plaid']);
           }
+        } else {
+          this.router.navigate(['/plaid']);
         }
       });
     }

--- a/frontend/src/app/services/plaid-guard.service.ts
+++ b/frontend/src/app/services/plaid-guard.service.ts
@@ -1,8 +1,5 @@
 import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
-import { ApiService } from './api.service';
-import { BackendService } from './backend.service';
-import { Router } from '@angular/router';
+import { Router, NavigationCancel } from '@angular/router';
 import { AuthService } from './auth.service';
 
 @Injectable({
@@ -15,9 +12,16 @@ export class PlaidGuardService {
 
   canActivate(): boolean {
     let status = this.authService.isPlaidSetup();
-    console.log(status);
     if (!status) {
-      this.router.navigate(['/plaid']);
+      this.router.events.subscribe((event) => {
+        if (event instanceof NavigationCancel) {
+          if(!this.router.navigated && this.authService.isLoggedIn()) {
+            this.authService.fetchUserInfo().then(() => this.router.navigate([event.url]));
+          } else {
+            this.router.navigate(['/plaid']);
+          }
+        }
+      });
     }
     return status;        
   }

--- a/frontend/src/environments/environment.prod.ts
+++ b/frontend/src/environments/environment.prod.ts
@@ -5,5 +5,14 @@ export const environment = {
   auth0_connection: 'Username-Password-Authentication',
   api_url: 'https://clearviewmoney.com/api',
   plaid_client_id: '56c75e0edb2afcb6184d2c0a',
-  plaid_public_key: 'd17298a88d20be6c0fb14bb7513747'
+  plaid_public_key: 'd17298a88d20be6c0fb14bb7513747',
+  plaid_default_config: {
+    apiVersion: "v2",
+    env: "sandbox",
+    token: null,
+    webhook: "https://clearviewmoney.com/dashboard",
+    product: ["auth"],
+    countryCodes: ['US'],
+    key: 'd17298a88d20be6c0fb14bb7513747',
+  }
 };

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -9,7 +9,16 @@ export const environment = {
   auth0_connection: 'Username-Password-Authentication',
   api_url: 'http://localhost:3000/api',
   plaid_client_id: '56c75e0edb2afcb6184d2c0a',
-  plaid_public_key: 'd17298a88d20be6c0fb14bb7513747'
+  plaid_public_key: 'd17298a88d20be6c0fb14bb7513747',
+  plaid_default_config: {
+    apiVersion: "v2",
+    env: "sandbox",
+    token: null,
+    webhook: "https://clearviewmoney.com/dashboard",
+    product: ["auth"],
+    countryCodes: ['US'],
+    key: 'd17298a88d20be6c0fb14bb7513747',
+  }
 };
 
 /*


### PR DESCRIPTION
- Added refactor to Plaid Guard so that each time the page gets refreshed we check for a NavigationCancel event ( only triggered when a Guard returns false ), in that case we fetch for the user data and then redirect to dashboard, this should never fail as a user can only be on /dashboard if he has successfully logged in and completed the plaid flow
- Moved Plaid config to environment variable